### PR TITLE
Python 2-3 compatibility patches, small bug fixes, np hist features

### DIFF
--- a/histogrammar/plot/bokeh.py
+++ b/histogrammar/plot/bokeh.py
@@ -19,6 +19,9 @@ from __future__ import absolute_import
 
 import math
 
+# python 2/3 compatibility fixes
+from histogrammar.util import *
+
 class HistogramMethods(object):
     def plotbokeh(self,glyphType="line",glyphSize=1,fillColor="red",lineColor="black",lineAlpha=1,fillAlpha=0.1,lineDash='solid'):
 

--- a/histogrammar/plot/root.py
+++ b/histogrammar/plot/root.py
@@ -19,6 +19,9 @@
 import math
 import types
 
+# python 2/3 compatibility fixes
+from histogrammar.util import *
+
 try:
     from collections import OrderedDict
 except ImportError:
@@ -229,7 +232,8 @@ class TwoDimensionallyHistogramMethods(object):
         import ROOT
         constructor = getattr(ROOT, "TH2" + binType)
         sample = self.values[0]
-        th2 = constructor(name, title, self.num, self.low, self.high, sample.num, sample.low, sample.high)
+        th2 = constructor(name, title, int(self.num), float(self.low), float(self.high), \
+                          int(sample.num), float(sample.low), float(sample.high))
         for i in xrange(self.num):
             for j in xrange(sample.num):
                 th2.SetBinContent(i + 1, j + 1, self.values[i].values[j].entries)
@@ -240,6 +244,7 @@ class SparselyTwoDimensionallyHistogramMethods(object):
         import ROOT
         constructor = getattr(ROOT, "TH2" + binType)
         yminBin, ymaxBin, ynum, ylow, yhigh = prepareTH2sparse(self)
-        th2 = constructor(name, title, self.num, self.low, self.high, ynum, ylow, yhigh)
+        th2 = constructor(name, title, int(self.num), float(self.low), float(self.high), \
+                          int(ynum), float(ylow), float(yhigh))
         setTH2sparse(self, yminBin, ymaxBin, th2)
         return th2

--- a/histogrammar/primitives/sparselybin.py
+++ b/histogrammar/primitives/sparselybin.py
@@ -222,7 +222,7 @@ class SparselyBin(Factory, Container):
         else:
             return (self.maxBin + 1) * self.binWidth + self.origin
 
-    def at(index):
+    def at(self, index):
         """Extract the container at a given index, if it exists."""
         return self.bins.get(index, None)
 
@@ -231,7 +231,7 @@ class SparselyBin(Factory, Container):
         """Get a sequence of filled indexes."""
         return sorted(self.keys)
 
-    def range(index):
+    def range(self, index):
         """Get the low and high edge of a bin (given by index number)."""
         return (index * self.binWidth + self.origin, (index + 1) * self.binWidth + self.origin)
     


### PR DESCRIPTION
Python 2-3 compatibility patches, small bug fixes, np hist features

- Added python 2-3 compatibility patches to files in histogrammar/plot/*.py
- histogrammar/plot/root.py: constructor fixes for ROOT TH2D histograms;
  needs explicit float and ints in constructor, apparently, not numpy floats or ints.
- Can now retrieve numpy histogram-style features: bin_edges, bin_values,
  bin_centers for Bin and Sparselybin histograms. 
  E.g. useful for rebinning or other calculations based on numpy histograms.
- Two small fixes in function definitions in sparselybin.py (range() and at()).