### PR TITLE
In sparselybin switch q array to floats before applying divide and floor

### DIFF
--- a/histogrammar/primitives/sparselybin.py
+++ b/histogrammar/primitives/sparselybin.py
@@ -363,7 +363,12 @@ class SparselyBin(Factory, Container):
         subweights[selection] = 0.0
         self.nanflow._numpy(data, subweights, shape)
 
-        q = q.copy()
+        # switch to float here like in bin.py else numpy throws
+        # TypeError on trivial integer cases such as:
+        # >>> q = numpy.array([1,2,3,4])
+        # >>> np.divide(q,1,q)
+        # >>> np.floor(q,q)
+        q = numpy.array(q, dtype=numpy.float64)
         neginfs = numpy.isneginf(q)
         posinfs = numpy.isposinf(q)
 


### PR DESCRIPTION
One more request I'm afraid, I hope it's the last one.
Could you turn this into tag 1.0.8 as well? Many thanks!

In sparselybin I switched the q array to floats before applying divide and floor. 
(In fact I see that the same is done for normally binned histograms.)
If not, for some reason numpy throws TypeError on trivial integer array cases such as:

>>> q = numpy.array([1,2,3,4])
>>> np.divide(q,1,q)
>>> np.floor(q,q)

which can easily happen if your default binwidth is 1. 

In fact, unless specified this is my default binning. 
So any sparse histograms filled with integers fail for me.
