### PR TITLE
Correcting the implementation of the ascii() method.

### DIFF
--- a/histogrammar/primitives/bin.py
+++ b/histogrammar/primitives/bin.py
@@ -172,7 +172,7 @@ class Bin(Factory, Container):
             ranges[i] = "[" + str(self.range(i))[1:]
             i += 1
      
-        printedValues = ["{0:<.2g}".format(v) for v in values]
+        printedValues = ["{0:<.4g}".format(v) for v in values]
         printedValuesWidth = max(len(x) for x in printedValues)
         formatter = "{0:<14} {1:<%s} {2:<65}" % printedValuesWidth
 

--- a/histogrammar/primitives/count.py
+++ b/histogrammar/primitives/count.py
@@ -194,13 +194,6 @@ class Count(Factory, Container):
     def _sparksql(self, jvm, converter):
         return converter.Count()   # TODO: handle transform
 
-    def toInt(self):
-        """Return intiger value of count"""
-        value = str(self)
-        end = len(value) - 1
-        value = float(value[7:end])
-        return int(value)
-
     @property
     def children(self):
         """List of sub-aggregators, to make it possible to walk the tree."""


### PR DESCRIPTION
I was too hasty in accepting the `Bin.ascii` pull request. The old implementation

   * strongly assumed that all `Bin` contents are `Count`, would throw missing method exceptions on other cases
   * extracted `entries` by string manipulation on the `repr`
   * assumed that histogram entries are all integers

This new version fixes those and improves formatting for floating point. Example with floating point entries:

```
                   0.0                                                    91.8002740623
                      +--------------------------------------------------------------+
underflow      0      |                                                              |
[-90.0, -80.0) 0      |                                                              |
[-80.0, -70.0) 0      |                                                              |
[-70.0, -60.0) 0      |                                                              |
[-60.0, -50.0) 0.7124 |                                                              |
[-50.0, -40.0) 2.596  |**                                                            |
[-40.0, -30.0) 5.61   |****                                                          |
[-30.0, -20.0) 24.18  |****************                                              |
[-20.0, -10.0) 38.64  |**************************                                    |
[-10.0, 0.0)   79.63  |******************************************************        |
[0.0, 10.0)    91.8   |**************************************************************|
[10.0, 20.0)   89.96  |************************************************************* |
[20.0, 30.0)   78.63  |*****************************************************         |
[30.0, 40.0)   53.53  |************************************                          |
[40.0, 50.0)   20.47  |**************                                                |
[50.0, 60.0)   8.473  |******                                                        |
[60.0, 70.0)   3.773  |***                                                           |
[70.0, 80.0)   0.7507 |*                                                             |
overflow       0.8724 |*                                                             |
nanflow        0      |                                                              |
                      +--------------------------------------------------------------+
```

Example with integer entries:

```
                 0.0                                                           2194.0
                    +--------------------------------------------------------------+
underflow      0    |                                                              |
[-90.0, -80.0) 0    |                                                              |
[-80.0, -70.0) 0    |                                                              |
[-70.0, -60.0) 2    |                                                              |
[-60.0, -50.0) 12   |                                                              |
[-50.0, -40.0) 41   |*                                                             |
[-40.0, -30.0) 186  |*****                                                         |
[-30.0, -20.0) 476  |*************                                                 |
[-20.0, -10.0) 969  |***************************                                   |
[-10.0, 0.0)   1610 |*********************************************                 |
[0.0, 10.0)    2194 |**************************************************************|
[10.0, 20.0)   2070 |**********************************************************    |
[20.0, 30.0)   1670 |***********************************************               |
[30.0, 40.0)   1029 |*****************************                                 |
[40.0, 50.0)   486  |**************                                                |
[50.0, 60.0)   176  |*****                                                         |
[60.0, 70.0)   67   |**                                                            |
[70.0, 80.0)   10   |                                                              |
overflow       1    |                                                              |
nanflow        0    |                                                              |
                    +--------------------------------------------------------------+
```