### PR TITLE
For SparselyBin hists fix setting of correct origin when adding hists

### DIFF
--- a/histogrammar/primitives/sparselybin.py
+++ b/histogrammar/primitives/sparselybin.py
@@ -134,7 +134,7 @@ class SparselyBin(Factory, Container):
             if self.origin != other.origin:
                 raise ContainerException("cannot add SparselyBins because origin differs ({0} vs {1})".format(self.origin, other.origin))
 
-            out = SparselyBin(self.binWidth, self.quantity, self.value.copy() if self.value is not None else None, self.nanflow + other.nanflow)
+            out = SparselyBin(self.binWidth, self.quantity, self.value.copy() if self.value is not None else None, self.nanflow + other.nanflow, self.origin)
             out.entries = self.entries + other.entries
             out.bins = self.bins.copy()
             for i, v in other.bins.items():

--- a/histogrammar/version.py
+++ b/histogrammar/version.py
@@ -16,7 +16,7 @@
 
 import re
 
-__version__ = "1.0.11"
+__version__ = "1.0.12"
 
 version = __version__
 


### PR DESCRIPTION
For SparselyBin histograms fix setting of correct origin when adding histograms.

Bump up version to 1.0.12