### PR TITLE
Improve null handling in pandas dataframes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Release notes
 =============
 
+Version 1.0.25, Apr 2021
+------------------------
+* Improve null handling in pandas dataframes, by inferring datatype using pandas' infer_dtype function.
+* nans in bool columns get converted to "NaN", so the column keeps True and False values in Categorize.
+* columns of type object get converted to strings using to_string(), of type string uses only_str().
+
 Version 1.0.24, Apr 2021
 ------------------------
 * Categorize histogram now handles nones and nans in friendlier way, they are converted to "NaN".

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Histograms and other aggregators may also be converted into CUDA code for inclus
 PyCUDA is available, they can also be filled from Numpy arrays by JIT-compiling the CUDA code.
 This Python implementation of histogrammar been tested to guarantee compatibility with its Scala implementation.
 
-Latest Python release: v1.0.24 (April 2021).
+Latest Python release: v1.0.25 (April 2021).
 
 Announcements
 =============

--- a/histogrammar/dfinterface/filling_utils.py
+++ b/histogrammar/dfinterface/filling_utils.py
@@ -49,8 +49,9 @@ def check_dtype(dtype):
             # this converts pandas types, such as pd.Int64, into numpy types
             dtype = type(dtype.type())
         dtype = np.dtype(dtype).type
-        if dtype in {np.str_, np.string_, np.object_}:
+        if dtype in {np.str_, np.string_}:
             dtype = np.dtype(str).type
+        # MB 20210404: nb.object_ is kept an object -> uses to_string(). str uses only_str()
     except BaseException:
         raise RuntimeError(f'unknown assigned datatype "{dtype}"')
     return dtype
@@ -95,11 +96,9 @@ def to_str(val):
                 )
             )
         )
-
     elif hasattr(val, "__str__"):
         return str(val)
-
-    return ""
+    return "None"
 
 
 def only_str(val):
@@ -127,9 +126,9 @@ def only_bool(val):
         return val
     elif hasattr(val, "__iter__") and not isinstance(val, str):
         return np.asarray(
-            [s if isinstance(s, (np.bool_, bool)) else np.nan for s in val]
+            [s if isinstance(s, (np.bool_, bool)) else "NaN" for s in val]
         )
-    return np.nan
+    return "NaN"
 
 
 def only_int(val):
@@ -165,6 +164,9 @@ def only_float(val):
 
 
 QUANTITY = {
+    # MB 20210404: to_string for object types b/c it's a mixed type
+    np.object: to_str,
+    np.object_: to_str,
     str: only_str,
     np.str_: only_str,
     int: only_int,

--- a/histogrammar/dfinterface/histogram_filler_base.py
+++ b/histogrammar/dfinterface/histogram_filler_base.py
@@ -405,7 +405,7 @@ class HistogramFillerBase(object):
         for col_list in features:
             for col in col_list:
 
-                dt = check_dtype(self.get_data_type(df, col))
+                dt = self.var_dtype.get(col, check_dtype(self.get_data_type(df, col)))
 
                 if col not in self.var_dtype:
                     self.var_dtype[col] = dt

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ NAME = "histogrammar"
 
 MAJOR = 1
 REVISION = 0
-PATCH = 24
+PATCH = 25
 DEV = False
 # NOTE: also update version at: README.rst
 

--- a/tests/test_spark_histogrammar.py
+++ b/tests/test_spark_histogrammar.py
@@ -264,8 +264,8 @@ def test_get_histograms_date(spark_co):
 def test_null_histograms(spark_co):
     spark = spark_co
 
-    data = [(None, None, None, None), (1, None, None, 2), (None, True, "Jones", None), (3, True, "USA", 4),
-            (4, False, "FL", 5)]
+    data = [(None, None, None, None), (1, None, None, 2.), (None, True, "Jones", None), (3, True, "USA", 4.),
+            (4, False, "FL", 5.)]
     columns = ["transaction", "isActive", "eyeColor", "t2"]
     sdf = spark.createDataFrame(data=data, schema=columns)
 


### PR DESCRIPTION
* Improve null handling in pandas dataframes, by inferring datatype using pandas' infer_dtype function.
* nans in bool columns get converted to "NaN", so the column keeps True and False values in Categorize.
* columns of type object get converted to strings using to_string(), of type string uses only_str().