### PR TITLE
Turn off specialize() for Count objects

### DIFF
--- a/histogrammar/defs.py
+++ b/histogrammar/defs.py
@@ -1351,9 +1351,9 @@ int main(int argc, char** argv) {{
     def _cudaStorageType(self):
         return self._c99StructName()
 
-    def fillnumpy(self, data):
+    def fillnumpy(self, data, weights=1.0):
         self._checkForCrossReferences()
-        self._numpy(data, 1.0, [None])
+        self._numpy(data, weights, shape=[None])
 
     def _checkNPQuantity(self, q, shape):
         import numpy

--- a/histogrammar/defs.py
+++ b/histogrammar/defs.py
@@ -123,6 +123,8 @@ class Factory(object):
         These objects wouldn't satisfy any of ``addImplicitMethod``'s checks anyway.
         """
         if spec:
+            # MB 20220517: warning, this is a slow function.
+            # Adding functions to each object, ideally avoid this.
             histogrammar.specialized.addImplicitMethods(self)
 
         self.fill = FillMethod(self, self.fill)
@@ -236,8 +238,12 @@ class Container(object):
 
     def __getstate__(self):
         state = dict(self.__dict__)
-        del state["fill"]
-        del state["plot"]
+        for s in ['fill', 'plot']:
+            # these states are set dynamically by FillMethod and PlotMethod, in factory.specialize().
+            # MB 20220517: turned off specialize() for Count objects,
+            # for which specialized fill and plot methods are not needed.
+            if s in state:
+                del state[s]
         return state
 
     def __setstate__(self, dict):

--- a/histogrammar/primitives/count.py
+++ b/histogrammar/primitives/count.py
@@ -50,7 +50,7 @@ class Count(Factory, Container):
             raise ValueError("entries ({0}) cannot be negative".format(entries))
         out = Count()
         out.entries = float(entries)
-        return out.specialize()
+        return out
 
     @staticmethod
     def ing(transform=identity):
@@ -69,7 +69,6 @@ class Count(Factory, Container):
         self.entries = 0.0
         self.transform = serializable(transform)
         super(Count, self).__init__()
-        self.specialize()
 
     @inheritdoc(Container)
     def zero(self):
@@ -80,7 +79,7 @@ class Count(Factory, Container):
         if isinstance(other, Count):
             out = Count(self.transform)
             out.entries = self.entries + other.entries
-            return out.specialize()
+            return out
         else:
             raise ContainerException("cannot add {0} and {1}".format(self.name, other.name))
 
@@ -106,7 +105,7 @@ class Count(Factory, Container):
         else:
             out = self.zero()
             out.entries = factor * self.entries
-            return out.specialize()
+            return out
 
     @inheritdoc(Container)
     def __rmul__(self, factor):

--- a/histogrammar/primitives/count.py
+++ b/histogrammar/primitives/count.py
@@ -207,7 +207,7 @@ class Count(Factory, Container):
     def _cudaStorageType(self):
         return "float"
 
-    def _numpy(self, data, weights, shape):
+    def _numpy(self, _, weights, shape):
         import numpy
         if isinstance(weights, numpy.ndarray):
             assert len(weights.shape) == 1


### PR DESCRIPTION
Turn off specialize() for Count objects, which is adding dedicated fill and plot
functions. This is slow, and not needed for Count objects.