### PR TITLE
Num bins fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,10 @@
 Release notes
 =============
 
+Version 1.0.29, June 2022
+-------------------------
+* Fix for machine-level rounding error, which can show up on in num_bins() call of Bin histogram.
+
 Version 1.0.28, June 2022
 -------------------------
 * Multiple performance updates, to Bin, SparselyBin and Categorize histograms.

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ PyCUDA is available, they can also be filled from Numpy arrays by JIT-compiling 
 
 This Python implementation of histogrammar been tested to guarantee compatibility with its Scala implementation.
 
-Latest Python release: v1.0.28 (June 2022).
+Latest Python release: v1.0.29 (June 2022).
 
 Announcements
 =============

--- a/histogrammar/primitives/bin.py
+++ b/histogrammar/primitives/bin.py
@@ -1004,8 +1004,8 @@ class Bin(Factory, Container):
             if np.isclose(high, self.low + self.bin_width() * maxBin):
                 maxBin -= 1
             high = self.low + self.bin_width() * (maxBin + 1)
-        # number of bins
-        num_bins = int((high - low) / self.bin_width())
+        # number of bins. use np.round to correct for machine level rounding errors
+        num_bins = int(np.round((high - low) / self.bin_width()))
         return num_bins
 
     def bin_width(self):
@@ -1096,7 +1096,8 @@ class Bin(Factory, Container):
             if np.isclose(high, self.low + self.bin_width() * maxBin):
                 maxBin -= 1
             high = self.low + self.bin_width() * (maxBin + 1)
-
+        # new low and high values reset, so redo num_bins
+        num_bins = self.num_bins(low, high)
         edges = np.linspace(low, high, num_bins + 1)
         return edges
 

--- a/histogrammar/primitives/sparselybin.py
+++ b/histogrammar/primitives/sparselybin.py
@@ -736,8 +736,6 @@ class SparselyBin(Factory, Container):
         elif low is not None and high is not None:
             if low > high:
                 raise RuntimeError('low {low} greater than high {high}'.format(low=low, high=high))
-        # number of bins, before low/high adjustments
-        num_bins = self.num_bins(low, high)
         # lowest edge
         if low is None:
             low = self.low
@@ -752,6 +750,8 @@ class SparselyBin(Factory, Container):
             if np.isclose(high, self.origin + self.bin_width() * maxBin):
                 maxBin -= 1
             high = self.origin + self.bin_width() * (maxBin + 1)
+        # number of bins, after low/high adjustments
+        num_bins = self.num_bins(low, high)
         edges = np.linspace(low, high, num_bins + 1)
         return edges
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ NAME = "histogrammar"
 
 MAJOR = 1
 REVISION = 0
-PATCH = 28
+PATCH = 29
 DEV = False
 # NOTE: also update version at: README.rst
 


### PR DESCRIPTION
fix: rounding error in num_bins call of Bin histogram

- Machine level rounding error can show up on in num_bins() call of Bin histogram.
- Code refactoring in bin_edges() call of Bin and SparselyBin histograms.